### PR TITLE
Allows player names to include characters that are illegal in filenames

### DIFF
--- a/ssbu_thumbnail_generator.py
+++ b/ssbu_thumbnail_generator.py
@@ -122,6 +122,12 @@ for num in range(len(tournament)):
     if (not (os.path.exists(tournament[num]))):
         os.makedirs(tournament[num])
     
+    #Remove characters that can't be used for filenames from player names
+    illlegal_characters = ['|', '#', '<', '>', '$', '+', '%', '&', '{', '}', '\\', '*', '?', '/', '!', '\'', '"', ':', '@', '`', '=']
+    for i in illlegal_characters:
+        player_1_name[num] = player_1_name[num].replace(i, '')
+        player_2_name[num] = player_2_name[num].replace(i, '')
+
     #Save Thumbnail with formatted name
     background.save("{}/{} - {} ({}) vs {} ({}) [{}].png".format(tournament[num], tournament[num], player_1_name[num],
                                                               player_1_character[num], player_2_name[num],


### PR DESCRIPTION
- Removes illegal characters from player names before they are written to files, but after the thumbnail is generated
- Most notably allows '|' for prefixes